### PR TITLE
Logfile path fixed

### DIFF
--- a/src/main/java/vg/civcraft/mc/civmenu/TOSManager.java
+++ b/src/main/java/vg/civcraft/mc/civmenu/TOSManager.java
@@ -24,7 +24,8 @@ public class TOSManager {
 	public TOSManager(CivMenu plugin) {
 		this.plugin = plugin;
 		registeredPlayers = new TreeMap<UUID, Long>();
-		logFile = new File("registeredPlayers.txt");
+		new File("plugins/CivMenu").mkdirs(); //this should already exist, but we do this anyway to make sure
+		logFile = new File("plugins/CivMenu/registeredPlayers.txt");
 		parseLogFile();
 	}
 	


### PR DESCRIPTION
This uses the native spigot folder structure, all those folders should already exist, it's where the plugin.yml and config.yml are stored.
